### PR TITLE
skillをローカル環境ですぐ使えるようにした

### DIFF
--- a/.claude/skills/codex-consultation
+++ b/.claude/skills/codex-consultation
@@ -1,0 +1,1 @@
+../../plugins/codex-consultation/skills/codex-consultation

--- a/.claude/skills/conversation-context-export
+++ b/.claude/skills/conversation-context-export
@@ -1,0 +1,1 @@
+../../plugins/conversation-context/skills/conversation-context-export

--- a/.claude/skills/conversation-context-import
+++ b/.claude/skills/conversation-context-import
@@ -1,0 +1,1 @@
+../../plugins/conversation-context/skills/conversation-context-import

--- a/.claude/skills/library-update-review
+++ b/.claude/skills/library-update-review
@@ -1,0 +1,1 @@
+../../plugins/library-update-review/skills/library-update-review

--- a/.claude/skills/sanity-review
+++ b/.claude/skills/sanity-review
@@ -1,0 +1,1 @@
+../../plugins/sanity-review/skills/sanity-review

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 *.log
 tmp/
+!.claude/
+.claude/*
+!.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .DS_Store
 *.log
 tmp/
-!.claude/
-.claude/*
-!.claude/skills/
+.claude/settings.local.json


### PR DESCRIPTION
## 問題

このリポジトリで開発しているAgent Skillは、動作テストするために一旦githubのmainブランチにpushして、marketplace経由でインストールしなければならない

skillの開発pull requestをmergeするまでskillの動作確認ができない

## 解決

`.claude/skills/` の下に全skillのシンボリックリンクを置いた

## 動作確認方法

「(pull requestのURL) が正気かレビューして」でリポジトリローカルのskillが発動する事を確認した
https://github.com/shokai/agent-skills/pull/9#issuecomment-4073771051

<img width="629" height="179" alt="image" src="https://github.com/user-attachments/assets/4a5423c5-724b-4c99-8540-66745fc0a657" />

